### PR TITLE
add context with timeout timeout to github api call issue#38

### DIFF
--- a/internal/config.go
+++ b/internal/config.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"reflect"
 	"sync"
+	"time"
 
 	goenv "github.com/Netflix/go-env"
 )
@@ -16,7 +17,8 @@ import (
 //	    DatabaseURL string `env:"DATABASE_URL"`
 //	}
 type Config struct {
-	OpenAIAPIKey string `env:"OPENAI_API_KEY"`
+	OpenAIAPIKey   string        `env:"OPENAI_API_KEY"`
+	ContextTimeout time.Duration `env:"CONTEXT_TIMEOUT,default=5s"`
 }
 
 // config is a singleton instance of Config

--- a/internal/config_test.go
+++ b/internal/config_test.go
@@ -1,14 +1,17 @@
 package internal
 
 import (
+	"fmt"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/suite"
 )
 
 const (
-	OPENAI_ENV_NAME = "OPENAI_API_KEY"
+	OPENAI_ENV_NAME          = "OPENAI_API_KEY"
+	CONTEXT_TIMEOUT_ENV_NAME = "CONTEXT_TIMEOUT"
 )
 
 type TestConfigSuite struct {
@@ -16,11 +19,13 @@ type TestConfigSuite struct {
 
 	// The original value before running the tests
 	// contained by `OPENAI_API_KEY` env
-	restoreOpenaiEnvValue string
+	restoreOpenaiEnvValue         string
+	restoreContextTimeoutEnvValue string
 }
 
 func (s *TestConfigSuite) SetupSuite() {
 	s.restoreOpenaiEnvValue = os.Getenv(OPENAI_ENV_NAME)
+	s.restoreContextTimeoutEnvValue = os.Getenv(CONTEXT_TIMEOUT_ENV_NAME)
 }
 
 func (s *TestConfigSuite) TearDownSuite() {
@@ -28,30 +33,43 @@ func (s *TestConfigSuite) TearDownSuite() {
 	if err != nil {
 		s.FailNowf("can not restore %s", OPENAI_ENV_NAME)
 	}
+	err = os.Setenv(CONTEXT_TIMEOUT_ENV_NAME, s.restoreContextTimeoutEnvValue)
+	if err != nil {
+		s.FailNowf("can not restore %s", OPENAI_ENV_NAME)
+	}
 }
 
 func (s *TestConfigSuite) TestGetConfig() {
 	apiKey := "api-key-openai"
+	contextTimeout := "3s"
 
 	err := os.Setenv(OPENAI_ENV_NAME, apiKey)
 	if err != nil {
 		s.FailNow("can not set openai api key for test")
+	}
+	err = os.Setenv(CONTEXT_TIMEOUT_ENV_NAME, contextTimeout)
+	if err != nil {
+		s.FailNow("can not set context timout for test")
 	}
 
 	config, err := GetConfig()
 	s.Nil(err)
 
 	expected := &Config{
-		OpenAIAPIKey: apiKey,
+		OpenAIAPIKey:   apiKey,
+		ContextTimeout: time.Duration(3) * time.Second,
 	}
+	fmt.Printf("expected: %v, actual : %v", expected, config)
 	s.Equal(expected, config)
 }
 
 func (s *TestConfigSuite) TestValidateConfigValidConfigs() {
 	apiKey := "api-key-openai"
+	contextTimeout := time.Duration(3) * time.Second
 
 	err := ValidateConfig(&Config{
-		OpenAIAPIKey: apiKey,
+		OpenAIAPIKey:   apiKey,
+		ContextTimeout: contextTimeout,
 	})
 
 	s.Nil(err)


### PR DESCRIPTION
Add a 5-second context with a timeout to GitHub Pull Request API call. #38 


cool project btw, would love to contribute :) 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Improved the `GetPullRequest` function with a timeout for better performance and reliability when fetching pull request data.
- **New Features**
	- Added a search functionality to the app.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->