### PR TITLE
feat/add flag to analyze button handler to prevent button spamming

### DIFF
--- a/main.go
+++ b/main.go
@@ -115,6 +115,13 @@ func onFileOpenButtonClickedHandler() {
 }
 
 func onAnalyzeButtonClickedHandler() {
+	// Prevent re-entry if already processing
+	if criticWindow.IsAnalyzeButtonActive {
+		dialog.ShowInformation("Analyze in Progress", "Analysis is already in progress. Please wait until the current process is complete.", *criticWindow.Window)
+
+		return
+	}
+
 	diff := criticWindow.DiffPanel.TextGrid.Text()
 	gptModel := criticWindow.PullRequestURLModal.GPTModel.Text
 
@@ -129,7 +136,12 @@ func onAnalyzeButtonClickedHandler() {
 		return
 	}
 
-	go getCodeReview(diff, gptModel)
+	criticWindow.IsAnalyzeButtonActive = true
+
+	go func() {
+		getCodeReview(diff, gptModel)
+		criticWindow.IsAnalyzeButtonActive = false
+	}()
 }
 
 func ResetCenterStage() {

--- a/ui/critic_window.go
+++ b/ui/critic_window.go
@@ -7,13 +7,14 @@ import (
 )
 
 type CriticWindow struct {
-	Size                fyne.Size // The size of the application window
-	App                 *fyne.App
-	Canvas              *fyne.Container                 // A box containing the ui components
-	Window              *fyne.Window                    // The main application window
-	ToolBar             *fyne.CanvasObject              // the top toolbar menu
-	ReportPanel         *components.ReportPanel         // the left panel
-	DiffPanel           *components.DiffPanel           // The right panel
-	ProgressBar         *components.ProgressBar         // The progress bar
-	PullRequestURLModal *components.PullRequestURLModal // The API key modal
+	Size                  fyne.Size // The size of the application window
+	App                   *fyne.App
+	Canvas                *fyne.Container                 // A box containing the ui components
+	Window                *fyne.Window                    // The main application window
+	ToolBar               *fyne.CanvasObject              // the top toolbar menu
+	ReportPanel           *components.ReportPanel         // the left panel
+	DiffPanel             *components.DiffPanel           // The right panel
+	ProgressBar           *components.ProgressBar         // The progress bar
+	PullRequestURLModal   *components.PullRequestURLModal // The API key modal
+	IsAnalyzeButtonActive bool                            // flag to sprevent spamming of analyze button
 }


### PR DESCRIPTION
#32 This PR adds a value `IsAnalyzeButtonActive` flag to the CriticWindow struct to prevent spamming of analyze button 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved the Analyze button to prevent multiple analyses from being initiated simultaneously.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->