### PR TITLE
feat/add TextWrapWord property to ReportPanel.Wrapping

### DIFF
--- a/ui/components/panel_report.go
+++ b/ui/components/panel_report.go
@@ -30,6 +30,7 @@ func NewReportPanel(containerSize fyne.Size, text string) *ReportPanel {
 	newSize := fyne.NewSize(containerSize.Width/2, containerSize.Height)
 	richText := widget.NewRichTextFromMarkdown(text)
 	richText.Scroll = container.ScrollBoth
+	richText.Wrapping = fyne.TextWrapWord
 	richText.Resize(newSize)
 
 	return &ReportPanel{Canvas: richText, Size: newSize}


### PR DESCRIPTION
This PR adds the fyne.TextWrapWord variable to the ReportPanel.Wrapping property. This allows any text in the canvas to wrap properly and avoid horizontal scrolling, attached below is the before vs. after
ref: #20 

### before
![image](https://github.com/kmesiab/ai-code-critic/assets/34355192/19bf8791-6007-44cb-9676-ca8da995c7b3)


### after
![image](https://github.com/kmesiab/ai-code-critic/assets/34355192/50d849fd-37d9-4e48-b067-1fe085e1d8e7)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Enhancements**
  - Improved text display in reports by enabling word wrapping for better readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->